### PR TITLE
bench: Set Content-Type header to POST requests

### DIFF
--- a/bench/benchmarker/webapp/client.go
+++ b/bench/benchmarker/webapp/client.go
@@ -45,6 +45,11 @@ func NewClient(config ClientConfig) (*Client, error) {
 
 	return &Client{
 		agent: ag,
+		requestModifiers: []func(*http.Request){func(req *http.Request) {
+			if req.Method == http.MethodPost && req.Header.Get("Content-Type") == "" {
+				req.Header.Add("Content-Type", "application/json; charset=utf-8")
+			}
+		}},
 	}, nil
 }
 

--- a/bench/benchmarker/webapp/client_initialize.go
+++ b/bench/benchmarker/webapp/client_initialize.go
@@ -25,6 +25,10 @@ func (c *Client) PostInitialize(ctx context.Context, reqBody *api.PostInitialize
 		return nil, err
 	}
 
+	for _, modifier := range c.requestModifiers {
+		modifier(req)
+	}
+
 	resp, err := c.agent.Do(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("POST /api/initialize のリクエストが失敗しました: %w", err)


### PR DESCRIPTION
Rust で利用予定のフレームワーク (Axum) ではリクエストボディの JSON をデシリアライズするには Content-Type ヘッダが application/json になっている必要があるので、ベンチマーカからのリクエストに Content-Type ヘッダをつけたいです。