### PR TITLE
go: Use Unix Epoch time as default value

### DIFF
--- a/webapp/go/owner_handlers.go
+++ b/webapp/go/owner_handlers.go
@@ -73,7 +73,7 @@ type ModelSales struct {
 func ownerGetSales(w http.ResponseWriter, r *http.Request) {
 	owner := r.Context().Value("owner").(*Owner)
 
-	since := time.Time{}
+	since := time.Unix(0, 0)
 	until := time.Date(9999, 12, 31, 23, 59, 59, 0, time.UTC)
 	if r.URL.Query().Get("since") != "" {
 		parsed, err := time.Parse(time.RFC3339Nano, r.URL.Query().Get("since"))


### PR DESCRIPTION
`GET /api/owner/sales` のエンドポイントにおいて `since` を指定しなかったときのデフォルト値が Go のゼロ値になっており、他言語に移植しづらく MySQL の datetime としても不正な値になってそうだったので、Unix Epoch の時刻あたりをデフォルト値にしたいです。