### PR TITLE
ベンチマーカーのログを修正（/api/app/payment-methodsのレスポンスに対するバリデーション）

### DIFF
--- a/bench/benchmarker/webapp/client_user.go
+++ b/bench/benchmarker/webapp/client_user.go
@@ -193,7 +193,7 @@ func (c *Client) AppPostPaymentMethods(ctx context.Context, reqBody *api.AppPost
 	defer closeBody(resp)
 
 	if resp.StatusCode != http.StatusNoContent {
-		return nil, fmt.Errorf("POST /api/app/payment-methodsへのリクエストに対して、期待されたHTTPステータスコードが確認できませんでした (expected:%d, actual:%d)", http.StatusOK, resp.StatusCode)
+		return nil, fmt.Errorf("POST /api/app/payment-methodsへのリクエストに対して、期待されたHTTPステータスコードが確認できませんでした (expected:%d, actual:%d)", http.StatusNoContent, resp.StatusCode)
 	}
 
 	resBody := &api.AppPostPaymentMethodsNoContent{}


### PR DESCRIPTION
195行目にある通り `/api/app/payment-methods` のレスポンスにはNO_CONTENTを期待している