### PR TITLE
go: Fix environment variable name in error message

### DIFF
--- a/webapp/go/main.go
+++ b/webapp/go/main.go
@@ -36,7 +36,7 @@ func setup() http.Handler {
 	}
 	_, err := strconv.Atoi(port)
 	if err != nil {
-		panic(fmt.Sprintf("failed to convert DB port number from DB_PORT environment variable into int: %v", err))
+		panic(fmt.Sprintf("failed to convert DB port number from ISUCON_DB_PORT environment variable into int: %v", err))
 	}
 	user := os.Getenv("ISUCON_DB_USER")
 	if user == "" {


### PR DESCRIPTION
#208 で実際に使う環境変数名とエラーメッセージ内の環境変数名がズレてしまっていたのを直します。