### PR TITLE
go: Use tx if tx is open

### DIFF
--- a/webapp/go/owner_handlers.go
+++ b/webapp/go/owner_handlers.go
@@ -117,7 +117,7 @@ func ownerGetSales(w http.ResponseWriter, r *http.Request) {
 	modelSalesByModel := map[string]int{}
 	for _, chair := range chairs {
 		rides := []Ride{}
-		if err := db.Select(&rides, "SELECT rides.* FROM rides JOIN ride_statuses ON rides.id = ride_statuses.ride_id WHERE chair_id = ? AND status = 'COMPLETED' AND updated_at BETWEEN ? AND ?", chair.ID, since, until); err != nil {
+		if err := tx.Select(&rides, "SELECT rides.* FROM rides JOIN ride_statuses ON rides.id = ride_statuses.ride_id WHERE chair_id = ? AND status = 'COMPLETED' AND updated_at BETWEEN ? AND ?", chair.ID, since, until); err != nil {
 			writeError(w, http.StatusInternalServerError, err)
 			return
 		}


### PR DESCRIPTION
`tx := db.Beginx()` した後に tx のコミットもロールバックもしてない状況で `db.Select()` するとコネクションが2つ必要になってしまい、おそらく意図してないので `tx.Select()` に直します。