### PR TITLE
go: Count chairs if there's no associated ride

### DIFF
--- a/webapp/go/app_handlers.go
+++ b/webapp/go/app_handlers.go
@@ -1014,14 +1014,15 @@ func appGetNearbyChairs(w http.ResponseWriter, r *http.Request) {
 				writeError(w, http.StatusInternalServerError, err)
 				return
 			}
-		}
-		status, err := getLatestRideStatus(tx, ride.ID)
-		if err != nil {
-			writeError(w, http.StatusInternalServerError, err)
-			return
-		}
-		if status != "COMPLETED" {
-			continue
+		} else {
+			status, err := getLatestRideStatus(tx, ride.ID)
+			if err != nil {
+				writeError(w, http.StatusInternalServerError, err)
+				return
+			}
+			if status != "COMPLETED" {
+				continue
+			}
 		}
 
 		// 5分以内に更新されている最新の位置情報を取得


### PR DESCRIPTION
`GET /api/app/nearby-chairs` において chair に関連付けられた ride が無いとき、現行の実装だと `ride` がゼロ値のまま進んで getLatestRideStatus() で行を見つけられず `sql: no rows in result set` で 500 になってしまいます。
おそらく chair に関連付けられた ride が無いときはスキップ (continue) するのが正しそうなのでそう直してみました。

自分が慣れてるので Ruby スクリプトですが…… 以下が再現リクエストを送る方法です。

<details>

```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'

  gem 'http-cookie'
end

require 'http-cookie'
require 'json'
require 'net/http'
require 'uri'

endpoint = URI.parse('http://localhost:8080')

jar = HTTP::CookieJar.new

Net::HTTP.start(endpoint.host, endpoint.port) do |http|
  # Initialize
  req = Net::HTTP::Post.new('/api/initialize')
  req.body = JSON.dump(payment_server: 'http://localhost:12345')
  req['content-type'] = 'application/json'
  res = http.request(req)
  res.value

  # Create user
  req = Net::HTTP::Post.new('/api/app/users')
  req.body = JSON.dump(
    username: "u-#{Time.now.to_i}",
    firstname: "f-#{Time.now.to_i}",
    lastname: "l-#{Time.now.to_i}",
    date_of_birth: "d-#{Time.now.to_i}",
  )
  req['content-type'] = 'application/json'
  res = http.request(req)
  res.value
  jar.parse(res['set-cookie'], endpoint + '/api/app/users')

  # Create owner
  req = Net::HTTP::Post.new('/api/owner/owners')
  req.body = JSON.dump(
    name: "n-#{Time.now.to_i}",
  )
  req['content-type'] = 'application/json'
  res = http.request(req)
  res.value
  chair_register_token = JSON.parse(res.body).fetch('chair_register_token')

  # Create chair
  req = Net::HTTP::Post.new('/api/chair/chairs')
  req.body = JSON.dump(
    name: "n-#{Time.now.to_i}",
    model: "m-#{Time.now.to_i}",
    chair_register_token:,
  )
  req['content-type'] = 'application/json'
  res = http.request(req)
  res.value

  # Get nearby chairs
  req = Net::HTTP::Get.new('/api/app/nearby-chairs?latitude=0&longitude=0')
  req['cookie'] = HTTP::Cookie.cookie_value(jar.cookies(endpoint + '/api/app/nearby-chairs'))
  res = http.request(req)
  res.value # <-- 500 Internal Server Error
end
```
</details>