### PR TITLE
go: Use calculateDistance() to calculate Manhattan distance

### DIFF
--- a/webapp/go/app_handlers.go
+++ b/webapp/go/app_handlers.go
@@ -1072,9 +1072,7 @@ func appGetNearbyChairs(w http.ResponseWriter, r *http.Request) {
 }
 
 func calculateFare(pickupLatitude, pickupLongitude, destLatitude, destLongitude int) int {
-	latDiff := max(destLatitude-pickupLatitude, pickupLatitude-destLatitude)
-	lonDiff := max(destLongitude-pickupLongitude, pickupLongitude-destLongitude)
-	meteredFare := farePerDistance * (latDiff + lonDiff)
+	meteredFare := farePerDistance * calculateDistance(pickupLatitude, pickupLongitude, destLatitude, destLongitude)
 	return initialFare + meteredFare
 }
 
@@ -1115,9 +1113,7 @@ func calculateDiscountedFare(tx *sqlx.Tx, userID string, req *Ride, pickupLatitu
 		}
 	}
 
-	latDiff := max(destLatitude-pickupLatitude, pickupLatitude-destLatitude)
-	lonDiff := max(destLongitude-pickupLongitude, pickupLongitude-destLongitude)
-	meteredFare := farePerDistance * (latDiff + lonDiff)
+	meteredFare := farePerDistance * calculateDistance(pickupLatitude, pickupLongitude, destLatitude, destLongitude)
 	discountedMeteredFare := max(meteredFare-discount, 0)
 
 	return initialFare + discountedMeteredFare, nil


### PR DESCRIPTION
app_handlers.go 内で既にマンハッタン距離を計算する関数が定義されているので、calculateFare() と calculateDiscountedFare() でもその関数を利用するようにして分かりやすくしてみました。どうでしょうか。
個人的には、ちゃんと読めば分かるんですけど `abs(a-b)` を求めるために `max(a-b, b-a)` していることがぱっと分からなかったので、その意味でも calculateDistance() のほうが分かりやすいかな…… と思いました。