### PR TITLE
bench: Fix expected status code of POST /api/app/users

### DIFF
--- a/bench/benchmarker/webapp/client_user.go
+++ b/bench/benchmarker/webapp/client_user.go
@@ -38,7 +38,7 @@ func (c *Client) AppPostRegister(ctx context.Context, reqBody *api.AppPostUsersR
 	defer closeBody(resp)
 
 	if resp.StatusCode != http.StatusCreated {
-		return nil, fmt.Errorf("POST /api/app/usersへのリクエストに対して、期待されたHTTPステータスコードが確認できませんでした (expected:%d, actual:%d)", http.StatusOK, resp.StatusCode)
+		return nil, fmt.Errorf("POST /api/app/usersへのリクエストに対して、期待されたHTTPステータスコードが確認できませんでした (expected:%d, actual:%d)", http.StatusCreated, resp.StatusCode)
 	}
 
 	resBody := &api.AppPostUsersCreated{}


### PR DESCRIPTION
`POST /api/app/users` で webapp が間違ったステータスコードを返したときのエラーメッセージが間違っているのを修正します。