### PR TITLE
python: remove owner_get_chair_detail

### DIFF
--- a/webapp/python/src/isuride/app/routers/owners.py
+++ b/webapp/python/src/isuride/app/routers/owners.py
@@ -10,7 +10,7 @@ from collections.abc import MutableMapping
 from datetime import datetime, timezone
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, Response
 from pydantic import BaseModel, StringConstraints
 from sqlalchemy import text
 from ulid import ULID
@@ -241,62 +241,3 @@ class OwnerGetChairDetailResponse(BaseModel):
     registered_at: int
     total_distance: int
     total_distance_updated_at: int | None  # TODO: omitemptyの対応がいるかも
-
-
-@router.get("/chairs/{chair_id}")
-def owner_get_chair_detail(
-    chair_id: str,
-    owner: Owner = Depends(owner_auth_middleware),
-) -> OwnerGetChairDetailResponse:
-    with engine.begin() as conn:
-        rows = conn.execute(
-            text(
-                """
-                SELECT id,
-                       owner_id,
-                       name,
-                       access_token,
-                       model,
-                       is_active,
-                       created_at,
-                       updated_at,
-                       IFNULL(total_distance, 0) AS total_distance,
-                       total_distance_updated_at
-                FROM chairs
-                       LEFT JOIN (SELECT chair_id,
-                                          SUM(IFNULL(distance, 0)) AS total_distance,
-                                          MAX(created_at)          AS total_distance_updated_at
-                                   FROM (SELECT chair_id,
-                                                created_at,
-                                                ABS(latitude - LAG(latitude) OVER (PARTITION BY chair_id ORDER BY created_at)) +
-                                                ABS(longitude - LAG(longitude) OVER (PARTITION BY chair_id ORDER BY created_at)) AS distance
-                                         FROM chair_locations) tmp
-                                   GROUP BY chair_id) distance_table ON distance_table.chair_id = chairs.id
-                WHERE owner_id = :owner_id AND id = :id
-                """
-            ),
-            {"owner_id": owner.id, "id": chair_id},
-        )
-
-        row = rows.fetchone()
-        if row is None:
-            raise HTTPException(status_code=404, detail="chair not found")
-        else:
-            chair = ChairWithDetail(**row)
-
-    resp = OwnerGetChairDetailResponse(
-        id=chair.id,
-        name=chair.name,
-        model=chair.model,
-        active=chair.is_active,
-        # TODO: ミリ秒への変換はこれで良いのだろうか
-        registered_at=int(chair.created_at.timestamp() * 1000),
-        total_distance=chair.total_distance,
-        total_distance_updated_at=None,
-    )
-    if chair.total_distance_updated_at is not None:
-        # TODO: ミリ秒への変換はこれで良いのだろうか
-        t = int(chair.total_distance_updated_at.timestamp() * 1000)
-        resp.total_distance_updated_at = t
-
-    return resp


### PR DESCRIPTION
2024/11/20の[仕様変更](https://scrapbox.io/isucon14/%E4%BB%95%E6%A7%98%E3%83%BB%E3%83%99%E3%83%B3%E3%83%81%E3%83%9E%E3%83%BC%E3%82%AB%E3%83%BC%E6%8C%99%E5%8B%95%E3%81%AE%E5%A4%89%E6%9B%B4%E3%83%AD%E3%82%B0)より

>  `GET /owner/chairs/{chair_id}`の`GET /owner/chairs`への統合
 	変更理由・内容
 		返している内容が重複しており、アプリ上で使用しないことになった
 		`GET /owner/chairs/{chair_id}`を削除
 	影響範囲
 		`GET /owner/chairs/{chair_id}`
 	PR（下記の変更と同時）
 		https://github.com/isucon/isucon14/pull/339