### PR TITLE
bench: Fix error message when sales differs

### DIFF
--- a/bench/benchmarker/world/owner.go
+++ b/bench/benchmarker/world/owner.go
@@ -159,7 +159,7 @@ func (p *Owner) ValidateSales(until time.Time, serverSide *GetOwnerSalesResponse
 			return fmt.Errorf("nameが一致しないデータがあります (id: %s, got: %s, want: %s)", chair.ID, chair.Name, sales.Name)
 		}
 		if sales.Sales != chair.Sales {
-			return fmt.Errorf("salesがずれているデータがあります (id: %s, got: %d, want: %d)", chair.ID, sales.Sales, chair.Sales)
+			return fmt.Errorf("salesがずれているデータがあります (id: %s, got: %d, want: %d)", chair.ID, chair.Sales, sales.Sales)
 		}
 	}
 


### PR DESCRIPTION
GET /api/owner/sales の結果が間違っているときのエラーメッセージを修正します。sales.Sales のほうが expected (want) のはず。