### PR TITLE
python3: use JST timezone（ローカル検証用）

### DIFF
--- a/webapp/python/src/isuride/app/routers/owners.py
+++ b/webapp/python/src/isuride/app/routers/owners.py
@@ -7,7 +7,7 @@ TODO: このdocstringを消す
 
 from collections import defaultdict
 from collections.abc import MutableMapping
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Response
@@ -19,6 +19,7 @@ from ..middlewares import owner_auth_middleware
 from ..models import Chair, Owner, Ride
 from ..sql import engine
 from ..utils import (
+    JST,
     datetime_fromtimestamp_millis,
     secure_random_str,
     sum_sales,
@@ -98,7 +99,7 @@ def owner_get_sales(
         since_dt = datetime_fromtimestamp_millis(since)
 
     if until is None:
-        until_dt = datetime(9999, 12, 31, 23, 59, 59, tzinfo=timezone.utc)
+        until_dt = datetime(9999, 12, 31, 23, 59, 59, tzinfo=JST)
     else:
         until_dt = datetime_fromtimestamp_millis(until)
 

--- a/webapp/python/src/isuride/app/utils.py
+++ b/webapp/python/src/isuride/app/utils.py
@@ -1,13 +1,15 @@
 import binascii
 import os
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from .models import Ride
 
 INITIAL_FARE: int = 500
 FARE_PER_DISTANCE: int = 100
+JST: ZoneInfo = ZoneInfo("Asia/Tokyo")
 
-EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+EPOCH = datetime(1970, 1, 1, tzinfo=ZoneInfo("Asia/Tokyo"))
 
 
 def secure_random_str(b: int) -> str:
@@ -21,7 +23,7 @@ def timestamp_millis(dt: datetime) -> int:
 
 
 def datetime_fromtimestamp_millis(t: int) -> datetime:
-    return EPOCH + timedelta(milliseconds=t)
+    return EPOCH + timedelta(hours=+9, milliseconds=t)
 
 
 def calculate_fare(pickup_latitude, pickup_longitude, dest_latitude, dest_longitude):


### PR DESCRIPTION
Python3 の実装において JST timezone を使用します

TODO: 実際の本番環境で使用するタイムゾーンがUTSの場合は変更が必要なので、確認を行う。
手元のベンチマーカーを通すことを優先するので本PRはそのままマージする