### PR TITLE
python3: fix 🐛 SQL when add a coupon for reward

### DIFF
--- a/webapp/python/src/isuride/app/routers/apps.py
+++ b/webapp/python/src/isuride/app/routers/apps.py
@@ -119,7 +119,7 @@ def app_post_users(r: AppPostUsersRequest, response: Response) -> AppPostUsersRe
                 ),
                 {
                     "user_id": inviter.id,
-                    "code": "RWD_" + r.invitation_code,
+                    "code_prefix": "RWD_" + r.invitation_code,
                     "discount": 1000,
                 },
             )


### PR DESCRIPTION
This PR fixes a small bug when insert a reward coupon in python3 code.