### PR TITLE
python3: implement custom error handler

### DIFF
--- a/webapp/python/src/isuride/app/main.py
+++ b/webapp/python/src/isuride/app/main.py
@@ -1,6 +1,7 @@
 import subprocess
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
 
@@ -23,6 +24,11 @@ class PostInitializeRequest(BaseModel):
 
 class PostInitializeResponse(BaseModel):
     language: str
+
+
+@app.exception_handler(HTTPException)
+def custom_http_exception_handler(_: Request, exc: HTTPException):
+    return JSONResponse(status_code=exc.status_code, content={"message": exc.detail})
 
 
 @app.post("/api/initialize")


### PR DESCRIPTION
Go実装と同様の形式でエラーレスポンスが返せるようにフックを実装します。

カスタム例外ハンドラを`fastapi.HTTPException`でキャッチします（下: 参考)
* 触った感じ大きくパフォーマンスが劣化することはなさそうです
* details が定義されていない場合はStatus Codeからデフォルトのエラーメッセージが返却されます
https://fastapi.tiangolo.com/ja/tutorial/handling-errors/#_4