### PR TITLE
[FE]モーダル周りのリファクタ

### DIFF
--- a/frontend/app/routes/client._index/route.tsx
+++ b/frontend/app/routes/client._index/route.tsx
@@ -1,5 +1,5 @@
 import type { MetaFunction } from "@remix-run/node";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import colors from "tailwindcss/colors";
 import {
   fetchAppGetNearbyChairs,
@@ -54,7 +54,7 @@ export default function Index() {
 
   const [locationSelectTarget, setLocationSelectTarget] =
     useState<LocationSelectTarget | null>(null);
-  
+
   const [selectedLocation, setSelectedLocation] = useState<Coordinate>();
   const onMove = useCallback((coordinate: Coordinate) => {
     setSelectedLocation(coordinate);
@@ -76,13 +76,12 @@ export default function Index() {
     }
   }, [locationSelectTarget, selectedLocation]);
 
-  const [isStatusModalOpen, setStatusModalOpen] = useState(false);
-  useEffect(() => {
-    setStatusModalOpen(
+  const isStatusModalOpen = useMemo(() => {
+    return (
       internalStatus !== undefined &&
-        ["MATCHING", "ENROUTE", "PICKUP", "CARRYING", "ARRIVED"].includes(
-          internalStatus,
-        ),
+      ["MATCHING", "ENROUTE", "PICKUP", "CARRYING", "ARRIVED"].includes(
+        internalStatus,
+      )
     );
   }, [internalStatus]);
 
@@ -299,7 +298,10 @@ export default function Index() {
         </Modal>
       )}
       {isStatusModalOpen && (
-        <Modal ref={statusModalRef} onClose={() => setStatusModalOpen(false)}>
+        <Modal
+          ref={statusModalRef}
+          onClose={() => setInternalStatus("COMPLETED")}
+        >
           {internalStatus === "MATCHING" && (
             <Matching
               destLocation={payload?.coordinate?.destination}
@@ -326,7 +328,11 @@ export default function Index() {
             />
           )}
           {internalStatus === "ARRIVED" && (
-            <Arrived onEvaluated={() => statusModalRef.current?.close()} />
+            <Arrived
+              onEvaluated={() => {
+                statusModalRef.current?.close();
+              }}
+            />
           )}
         </Modal>
       )}


### PR DESCRIPTION
- "from" | "to" | undefined の差分でモーダルが出ているロジックになっている箇所を、 ボタン押下後に開閉するように(from => from / to => to の変化の際に開くのが期待値?)
- 不要なuseEffectの修正