### PR TITLE
python: use naive UTC

### DIFF
--- a/webapp/python/app/owner_handlers.py
+++ b/webapp/python/app/owner_handlers.py
@@ -20,7 +20,6 @@ from .middlewares import owner_auth_middleware
 from .models import Chair, Owner, Ride
 from .sql import engine
 from .utils import (
-    UTC,
     datetime_fromtimestamp_millis,
     secure_random_str,
     sum_sales,
@@ -100,7 +99,7 @@ def owner_get_sales(
         since_dt = datetime_fromtimestamp_millis(since)
 
     if until is None:
-        until_dt = datetime(9999, 12, 31, 23, 59, 59, tzinfo=UTC)
+        until_dt = datetime(9999, 12, 31, 23, 59, 59)
     else:
         until_dt = datetime_fromtimestamp_millis(until)
 

--- a/webapp/python/app/utils.py
+++ b/webapp/python/app/utils.py
@@ -1,16 +1,14 @@
 import binascii
 import os
 from datetime import datetime, timedelta
-from zoneinfo import ZoneInfo
 
-# if typing.TYPE_CHECKINGの中に入れた方がいいかも
+# TODO: if typing.TYPE_CHECKINGの中に入れた方がいいかも
 from .models import Ride
 
 INITIAL_FARE: int = 500
 FARE_PER_DISTANCE: int = 100
-UTC: ZoneInfo = ZoneInfo("UTC")
 
-EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+EPOCH = datetime(1970, 1, 1)
 
 
 def secure_random_str(b: int) -> str:
@@ -19,7 +17,6 @@ def secure_random_str(b: int) -> str:
 
 
 def timestamp_millis(dt: datetime) -> int:
-    dt = dt.astimezone(UTC)
     return (dt - EPOCH) // timedelta(milliseconds=1)
 
 


### PR DESCRIPTION
## 概要
アプリケーション内の`datetime`オブジェクトをすべてnaiveで扱うようにする。

## ベンチマーク結果
8f7705d に対してベンチマークを回したところ (id: [604](https://portal.isucon.jp/contestant/benchmark_jobs/604)) 以下の結果になった:

- スコア: 1110
- 「salesがずれているデータがあります」: 9件