### PR TITLE
python: provisioning Python webapp with uv

### DIFF
--- a/provisioning/ansible/roles/webapp/tasks/python.yaml
+++ b/provisioning/ansible/roles/webapp/tasks/python.yaml
@@ -6,17 +6,12 @@
     path: /home/isucon/webapp/python
     state: directory
 
-- name: install pipenv
-  become: true
-  become_user: isucon
-  shell: |
-    /home/isucon/.x pip install pipenv
-
+# ここでPythonインタプリタもダウンロードされる
 - name: Build isuride-python
   become: true
   become_user: isucon
   shell: |
-    /home/isucon/.x pipenv install
+    /home/isucon/.local/bin/uv sync --locked --no-dev
   args:
     chdir: /home/isucon/webapp/python
 

--- a/provisioning/ansible/roles/xbuildwebapp/tasks/main.yml
+++ b/provisioning/ansible/roles/xbuildwebapp/tasks/main.yml
@@ -70,8 +70,9 @@
     --enable-sysvsem --enable-sysvshm --enable-sysvmsg --enable-mbregex \
     --enable-mbstring --enable-pcntl --enable-sockets --with-curl --enable-zip
 
-- name: Install Python
+- name: Install uv for Python
   become: true
   become_user: isucon
   shell:
-    cmd: /opt/xbuild/python-install 3.13.0 /home/isucon/local/python
+    cmd: curl -LsSf https://astral.sh/uv/install.sh | sh
+    creates: /home/isucon/.local/bin/uv


### PR DESCRIPTION
Provisioning Python webapp with uv

- uvのインストールは通った: https://github.com/isucon/isucon14/actions/runs/12065757679/job/33647802537#step:9:164
- uv syncも通った: https://github.com/isucon/isucon14/actions/runs/12065512370/job/33648896576#step:13:727