### PR TITLE
python: use custom handler for validation error

### DIFF
--- a/webapp/python/app/main.py
+++ b/webapp/python/app/main.py
@@ -6,6 +6,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 
 from . import app_handlers, chair_handlers, internal_handlers, owner_handlers
 from .sql import engine
@@ -25,8 +26,8 @@ class PostInitializeResponse(BaseModel):
     language: str
 
 
-@app.exception_handler(HTTPStatus.INTERNAL_SERVER_ERROR)
-def internal_exception_handler(_: Request, exc: Exception) -> JSONResponse:
+@app.exception_handler(SQLAlchemyError)
+def sql_alchemy_error_handler(_: Request, exc: SQLAlchemyError) -> JSONResponse:
     return JSONResponse(
         status_code=HTTPStatus.INTERNAL_SERVER_ERROR, content={"message": str(exc)}
     )
@@ -37,7 +38,8 @@ def validation_exception_handler(
     _: Request, exc: RequestValidationError
 ) -> JSONResponse:
     return JSONResponse(
-        status_code=HTTPStatus.METHOD_NOT_ALLOWED, content={"message": str(exc)}
+        status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        content={"message": str(exc.errors())},
     )
 
 


### PR DESCRIPTION
close #471 
バリデーションを {"message": } の形式で返却する

