### PR TITLE
go: Don't use db in transaction

### DIFF
--- a/webapp/go/chair_handlers.go
+++ b/webapp/go/chair_handlers.go
@@ -203,7 +203,7 @@ func chairGetNotification(w http.ResponseWriter, r *http.Request) {
 
 	if err := tx.Get(&yetSentRideStatus, `SELECT * FROM ride_statuses WHERE ride_id = ? AND chair_sent_at IS NULL ORDER BY created_at ASC LIMIT 1`, ride.ID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			status, err = getLatestRideStatus(db, ride.ID)
+			status, err = getLatestRideStatus(tx, ride.ID)
 			if err != nil {
 				writeError(w, http.StatusInternalServerError, err)
 				return


### PR DESCRIPTION
#491 の修正です。begin した後に tx ではなく db を使うと #250 と同様の問題があるので、トランザクション内では tx を使うよう直します。