### PR TITLE
go: Commit transaction in GET /api/chair/notification

### DIFF
--- a/webapp/go/chair_handlers.go
+++ b/webapp/go/chair_handlers.go
@@ -231,6 +231,11 @@ func chairGetNotification(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if err := tx.Commit(); err != nil {
+		writeError(w, http.StatusInternalServerError, err)
+		return
+	}
+
 	writeJSON(w, http.StatusOK, &chairGetNotificationResponse{
 		Data: &chairGetNotificationResponseData{
 			RideID: ride.ID,


### PR DESCRIPTION
#491 の修正です。`yetSentRideStatus.ID != ""` のときは update 文を実行するので、最後に commit する必要があると思います。