### PR TITLE
ruby: Enable YJIT

### DIFF
--- a/provisioning/ansible/roles/xbuildwebapp/tasks/main.yml
+++ b/provisioning/ansible/roles/xbuildwebapp/tasks/main.yml
@@ -56,7 +56,8 @@
   become: true
   become_user: isucon
   shell:
-    cmd: MAKE_OPTS=-j$(nproc) /opt/xbuild/ruby-install 3.3.6 /home/isucon/local/ruby
+    # Add rustc path to enable YJIT
+    cmd: PATH=/home/isucon/.cargo/bin:$PATH MAKE_OPTS=-j$(nproc) /opt/xbuild/ruby-install 3.3.6 /home/isucon/local/ruby
 
 - name: Install PHP
   become: true


### PR DESCRIPTION
YJIT が有効になるように Ruby をビルドします。

YJIT を有効化するにはビルド時に Rust コンパイラ (rustc) が必要です。

> You will need to install: - A C compiler such as GCC or Clang - GNU Make and Autoconf - The Rust compiler rustc and Cargo (if you want to build in dev/debug mode) - The Rust version must be >= 1.58.0.
> https://docs.ruby-lang.org/en/3.3/yjit/yjit_md.html

ISUCON の環境では先に Rust 初期実装用に rustc がインストールされているので、その rustc にパスが通った状態で Ruby をビルド・インストールするようにしました。