### PR TITLE
chore: set concurrency for workflows

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,6 +16,11 @@ on:
       - .github/workflows/go.yml
       - development/compose-go.yml
       - development/dockerfiles/Dockerfile.go
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -16,6 +16,11 @@ on:
       - .github/workflows/node.yml
       - development/compose-node.yml
       - development/dockerfiles/Dockerfile.node
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/perl.yml
+++ b/.github/workflows/perl.yml
@@ -16,6 +16,11 @@ on:
       - .github/workflows/perl.yml
       - development/compose-perl.yml
       - development/dockerfiles/Dockerfile.perl
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,6 +16,11 @@ on:
       - .github/workflows/php.yml
       - development/compose-php.ci.yml
       - development/dockerfiles/Dockerfile.ci.php
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,6 +16,11 @@ on:
       - .github/workflows/python.yml
       - development/compose-python.yml
       - development/dockerfiles/Dockerfile.python
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -16,6 +16,11 @@ on:
       - .github/workflows/ruby.yml
       - development/compose-ruby.yml
       - development/dockerfiles/Dockerfile.ruby
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,11 @@ on:
       - .github/workflows/rust.yml
       - development/compose-rust.yml
       - development/dockerfiles/Dockerfile.rust
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build


### PR DESCRIPTION
pushするたびに実行されてpush回数が多いとactionの時間をたくさん消費するため