### PR TITLE
[FE] 評価後の現在地、目的地をリセットするように

### DIFF
--- a/frontend/app/routes/client._index/route.tsx
+++ b/frontend/app/routes/client._index/route.tsx
@@ -272,6 +272,8 @@ export default function Index() {
             <Arrived
               onEvaluated={() => {
                 statusModalRef.current?.close();
+                setCurrentLocation(destLocation);
+                setDestLocation(undefined);
               }}
             />
           )}


### PR DESCRIPTION
relates: https://github.com/isucon/isucon14/issues/241

下記に対応しました。
> 評価が完了したときに、現在位置に目的地をセット、目的地を空にする