### PR TITLE
[FE] 街の領域に色を付けるように

### DIFF
--- a/frontend/app/components/modules/map/map-data.ts
+++ b/frontend/app/components/modules/map/map-data.ts
@@ -57,12 +57,12 @@ export const TownList = [
     name: "チェアタウン",
     centerCoordinate: { latitude: 0, longitude: 0 },
     image: { src: "/images/town.svg", width: 500, height: 500 },
-    color: "emerald",
+    color: "#FF3600",
   },
   {
     name: "コシカケシティ",
     centerCoordinate: { latitude: 300, longitude: 300 },
     image: { src: "/images/town.svg", width: 500, height: 500 },
-    color: "amber",
+    color: "#0089A2",
   },
 ] satisfies Town[];

--- a/frontend/app/components/modules/map/map.tsx
+++ b/frontend/app/components/modules/map/map.tsx
@@ -282,12 +282,13 @@ const TownLayer = memo(function TownLayer() {
             >
               <div
                 role="presentation"
-                className={`absolute rounded-full bg-neutral-300 bg-opacity-40 border-4 border-${color}-500`}
+                className="absolute rounded-full bg-neutral-100 bg-opacity-40 border-4 border-neutral-200"
                 style={{
                   width: image.width + 20,
                   height: image.width + 20,
                   top: -10,
                   left: -10,
+                  borderColor: color,
                 }}
               ></div>
               <img
@@ -300,7 +301,8 @@ const TownLayer = memo(function TownLayer() {
               <div className="absolute bottom-[-54px] w-full text-center">
                 <Text
                   tagName="span"
-                  className={`px-3 py-1 bg-${color}-600 text-white rounded-md`}
+                  className="px-3 py-1 text-white rounded-md"
+                  style={{ backgroundColor: color }}
                   size="sm"
                 >
                   {name}

--- a/frontend/app/components/primitives/text/text.tsx
+++ b/frontend/app/components/primitives/text/text.tsx
@@ -11,6 +11,7 @@ type TextProps = PropsWithChildren<{
   size?: Size;
   variant?: Variant;
   className?: string;
+  style?: React.CSSProperties;
 }>;
 
 const getSizeClass = (size?: Size) => {

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -3,5 +3,4 @@ import type { Config } from "tailwindcss";
 export default {
   content: ["./app/**/{**,.client,.server}/**/*.{js,jsx,ts,tsx}"],
   plugins: [],
-  safelist: [{ pattern: /bg-.+-600/ }, { pattern: /border-.+-500/ }],
 } satisfies Config;


### PR DESCRIPTION
relates: https://github.com/isucon/isucon14/issues/241

こちらに対応しました
>  チェアタウン/コシカケシティに色をつける

<img width="49%" src="https://github.com/user-attachments/assets/c98ef39f-d5c9-4602-836d-019796049a8e" alt="city_01" />
<img width="49%" src="https://github.com/user-attachments/assets/6bb42293-e29e-4bf7-873d-3547d41baf41" alt="city_02" />
