### PR TITLE
python: log errors in exception handlers

### DIFF
--- a/webapp/python/app/main.py
+++ b/webapp/python/app/main.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from http import HTTPStatus
 
 from fastapi import FastAPI, HTTPException, Request
@@ -50,8 +51,10 @@ def post_initialize(req: PostInitializeRequest) -> PostInitializeResponse:
 
 @app.exception_handler(SQLAlchemyError)
 def sql_alchemy_error_handler(_: Request, exc: SQLAlchemyError) -> JSONResponse:
+    message = str(exc)
+    print(message, file=sys.stderr)
     return JSONResponse(
-        status_code=HTTPStatus.INTERNAL_SERVER_ERROR, content={"message": str(exc)}
+        status_code=HTTPStatus.INTERNAL_SERVER_ERROR, content={"message": message}
     )
 
 
@@ -59,12 +62,16 @@ def sql_alchemy_error_handler(_: Request, exc: SQLAlchemyError) -> JSONResponse:
 def validation_exception_handler(
     _: Request, exc: RequestValidationError
 ) -> JSONResponse:
+    message = str(exc.errors())
+    print(message, file=sys.stderr)
     return JSONResponse(
         status_code=HTTPStatus.METHOD_NOT_ALLOWED,
-        content={"message": str(exc.errors())},
+        content={"message": message},
     )
 
 
 @app.exception_handler(HTTPException)
 def custom_http_exception_handler(_: Request, exc: HTTPException) -> JSONResponse:
-    return JSONResponse(status_code=exc.status_code, content={"message": exc.detail})
+    message = exc.detail
+    print(message, file=sys.stderr)
+    return JSONResponse(status_code=exc.status_code, content={"message": message})


### PR DESCRIPTION
## 概要
例外ハンドラの中でエラーメッセージをログするようにした。Go実装では`writeError`関数の中に対応する処理がある:
https://github.com/isucon/isucon14/blob/06f225545253294e28d5c5acb1c06b24c12bd84f/webapp/go/main.go#L175

## 動作確認
SQL文の`SELECT`を`SSELECT`にtypoしてみる。

元の実装ではアクセスログしか出ない:
```
127.0.0.1:59028 - "GET /api/internal/matching HTTP/1.1" 500
```

このパッチを当てると以下のようにログが出る。
```
(pymysql.err.ProgrammingError) (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'SSELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at LIMIT 1' at line 1")
[SQL: SSELECT * FROM rides WHERE chair_id IS NULL ORDER BY created_at LIMIT 1]
(Background on this error at: https://sqlalche.me/e/20/f405)
127.0.0.1:58968 - "GET /api/internal/matching HTTP/1.1" 500
```