### PR TITLE
[FE] 小さい幅の時の運賃の表示崩れを修正

### DIFF
--- a/frontend/app/components/modules/price/price.tsx
+++ b/frontend/app/components/modules/price/price.tsx
@@ -19,16 +19,21 @@ export const Price: FC<PriceTextProps> = ({
 }) => {
   return (
     <div
-      className={twMerge("flex flex-row space-x-1 items-center", className)}
+      className={twMerge(
+        "flex flex-col min-[440px]:flex-row space-x-1 items-center",
+        className,
+      )}
       {...props}
     >
-      <MoneyIcon width={30} height={30} />
-      {pre && (
-        <Text tagName="span" className="pr-2">
-          {pre}:
-        </Text>
-      )}
-      <PriceText value={value} />
+      <div className="flex items-center space-x-1">
+        <MoneyIcon width={30} height={30} />
+        {pre && (
+          <Text tagName="span" className="pr-2">
+            {pre}:
+          </Text>
+        )}
+        <PriceText value={value} />
+      </div>
       {!!discount && (
         <Text
           tagName="span"


### PR DESCRIPTION
https://github.com/isucon/isucon14/issues/241#issuecomment-2516745885
>小さい画面のときに推定料金の金額表示が崩れる

<img width="883" alt="image" src="https://github.com/user-attachments/assets/4671e1e9-6ce8-4827-b830-0cb797081616">
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/49976034-57da-420c-ade9-44d0949e303e">
