### PR TITLE
python: return 400 for RequestValidationError

### DIFF
--- a/webapp/python/app/main.py
+++ b/webapp/python/app/main.py
@@ -65,7 +65,7 @@ def validation_exception_handler(
     message = str(exc.errors())
     print(message, file=sys.stderr)
     return JSONResponse(
-        status_code=HTTPStatus.METHOD_NOT_ALLOWED,
+        status_code=HTTPStatus.BAD_REQUEST,
         content={"message": message},
     )
 


### PR DESCRIPTION
`RequestValidationError`に対して`400 Bad Request`を返すようにする。

Go実装:

```
$ curl -i -XPOST -H 'Content-Type: application/json' -d '{"foo": "bar"}' localhost:8080/api/owner/owners
HTTP/1.1 400 Bad Request
Content-Type: application/json;charset=utf-8
Date: Fri, 06 Dec 2024 12:17:25 GMT
Content-Length: 53

{"message":"some of required fields(name) are empty"}
```

Python実装 (Before):

```
$ curl -i -XPOST -H 'Content-Type: application/json' -d '{"foo": "bar"}' localhost:8080/api/owner/owners
HTTP/1.1 405 Method Not Allowed
date: Fri, 06 Dec 2024 12:16:00 GMT
server: uvicorn
content-length: 110
content-type: application/json

{"message":"[{'type': 'missing', 'loc': ('body', 'name'), 'msg': 'Field required', 'input': {'foo': 'bar'}}]"}
```

Python実装 (After):

```
$ curl -i -XPOST -H 'Content-Type: application/json' -d '{"foo": "bar"}' localhost:8080/api/owner/owners
HTTP/1.1 400 Bad Request
date: Fri, 06 Dec 2024 12:20:05 GMT
server: uvicorn
content-length: 110
content-type: application/json

{"message":"[{'type': 'missing', 'loc': ('body', 'name'), 'msg': 'Field required', 'input': {'foo': 'bar'}}]"}
```