### PR TITLE
python: fix type hint in app_handlers.py

### DIFF
--- a/webapp/python/app/app_handlers.py
+++ b/webapp/python/app/app_handlers.py
@@ -592,14 +592,12 @@ class AppGetNotificationResponse(BaseModel):
 
 @router.get(
     "/notification",
-    response_model=AppGetNotificationResponse,
     status_code=HTTPStatus.OK,
     response_model_exclude_none=True,
 )
 def app_get_notification(
     user: Annotated[User, Depends(app_auth_middleware)],
-    response: Response,
-) -> AppGetNotificationResponse | Response:
+) -> AppGetNotificationResponse:
     with engine.begin() as conn:
         row = conn.execute(
             text(


### PR DESCRIPTION
#711  で response を使用しなくなったので、型ヒントと引数を更新します