### PR TITLE
rust: Increase default pool size

### DIFF
--- a/webapp/rust/src/main.rs
+++ b/webapp/rust/src/main.rs
@@ -22,15 +22,17 @@ async fn main() -> anyhow::Result<()> {
     let password = std::env::var("ISUCON_DB_PASSWORD").unwrap_or_else(|_| "isucon".to_owned());
     let dbname = std::env::var("ISUCON_DB_NAME").unwrap_or_else(|_| "isuride".to_owned());
 
-    let pool = sqlx::MySqlPool::connect_with(
-        sqlx::mysql::MySqlConnectOptions::default()
-            .host(&host)
-            .port(port)
-            .username(&user)
-            .password(&password)
-            .database(&dbname),
-    )
-    .await?;
+    let pool = sqlx::mysql::MySqlPoolOptions::new()
+        .max_connections(50)
+        .connect_with(
+            sqlx::mysql::MySqlConnectOptions::default()
+                .host(&host)
+                .port(port)
+                .username(&user)
+                .password(&password)
+                .database(&dbname),
+        )
+        .await?;
 
     let app_state = AppState { pool };
 


### PR DESCRIPTION
sqlx のデフォルトのプールサイズの上限がわりと小さいので、最初からある程度引き上げておきます。ISUCON12 Final に合わせて適当に50くらいで。
https://github.com/isucon/isucon12-final/blob/d31d92c7f0df9fa1559270ffb9481ec8a610edf0/webapp/rust/src/main.rs#L110