### PR TITLE
【Don't merge】 python3: implement server side events

### DIFF
--- a/webapp/python/app/app_handlers.py
+++ b/webapp/python/app/app_handlers.py
@@ -587,7 +587,7 @@ class AppGetNotificationResponse(BaseModel):
 
 
 @router.get(
-    "/notification",
+    "/notification_test",
     response_model=AppGetNotificationResponse,
     status_code=HTTPStatus.OK,
     response_model_exclude_none=True,

--- a/webapp/python/app/main.py
+++ b/webapp/python/app/main.py
@@ -9,7 +9,13 @@ from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 
-from . import app_handlers, chair_handlers, internal_handlers, owner_handlers
+from . import (
+    app_handlers,
+    chair_handlers,
+    internal_handlers,
+    owner_handlers,
+    sse_handlers,
+)
 from .sql import engine
 
 app = FastAPI()
@@ -17,6 +23,7 @@ app.include_router(app_handlers.router)
 app.include_router(chair_handlers.router)
 app.include_router(internal_handlers.router)
 app.include_router(owner_handlers.router)
+app.include_router(sse_handlers.router)
 
 
 class PostInitializeRequest(BaseModel):

--- a/webapp/python/app/sse_handlers.py
+++ b/webapp/python/app/sse_handlers.py
@@ -1,0 +1,121 @@
+import time
+from http import HTTPStatus
+
+from fastapi import APIRouter, Request, HTTPException
+from sqlalchemy import text
+from sse_starlette.sse import EventSourceResponse
+
+from .app_handlers import (
+    AppGetNotificationResponseChair,
+    AppGetNotificationResponseData,
+    Coordinate,
+    calculate_discounted_fare,
+    get_chair_stats,
+    get_latest_ride_status,
+)
+from .middlewares import app_auth_middleware
+from .models import Chair, Ride
+from .sql import engine
+from .utils import timestamp_millis
+
+router = APIRouter()
+
+
+@router.get("/api/app/notification")
+def app_get_notification_sse(
+    request: Request,
+) -> EventSourceResponse:
+    user = app_auth_middleware(request.cookies.get("app_session"))
+    last_ride = None
+    last_ride_status = None
+
+    def event_stream():
+        nonlocal request
+
+        def f():
+            nonlocal last_ride, last_ride_status, user
+            with engine.begin() as conn:
+                row = conn.execute(
+                    text(
+                        "SELECT * FROM rides WHERE user_id = :user_id ORDER BY created_at DESC LIMIT 1"
+                    ),
+                    {"user_id": user.id},
+                ).fetchone()
+                if row is None:
+                    yield "data: {}"
+
+                ride = Ride.model_validate(row)
+                status = get_latest_ride_status(conn, ride.id)
+                if (
+                    (last_ride is not None)
+                    and (ride.id == last_ride.id)
+                    and (status == last_ride_status)
+                ):
+                    yield "data: {}"
+
+                fare = calculate_discounted_fare(
+                    conn,
+                    user.id,
+                    ride,
+                    ride.pickup_latitude,
+                    ride.pickup_longitude,
+                    ride.destination_latitude,
+                    ride.destination_longitude,
+                )
+                app_get_notification_response_chair = None
+
+                if ride.chair_id:
+                    row = conn.execute(
+                        text("SELECT * FROM chairs WHERE id = :chair_id"),
+                        {"chair_id": ride.chair_id},
+                    ).fetchone()
+                    if row is None:
+                        raise HTTPException(
+                            status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+                        )
+                    chair = Chair.model_validate(row)
+
+                    row = conn.execute(
+                        text("SELECT * FROM chairs WHERE id = :chair_id"),
+                        {"chair_id": ride.chair_id},
+                    ).fetchone()
+                    if row is None:
+                        raise HTTPException(
+                            status_code=HTTPStatus.INTERNAL_SERVER_ERROR
+                        )
+                    stats = get_chair_stats(conn, chair.id)
+                    app_get_notification_response_chair = (
+                        AppGetNotificationResponseChair(
+                            id=chair.id,
+                            name=chair.name,
+                            model=chair.model,
+                            stats=stats,
+                        )
+                    )
+                data = AppGetNotificationResponseData(
+                    ride_id=ride.id,
+                    pickup_coordinate=Coordinate(
+                        latitude=ride.pickup_latitude, longitude=ride.pickup_longitude
+                    ),
+                    destination_coordinate=Coordinate(
+                        latitude=ride.destination_latitude,
+                        longitude=ride.destination_longitude,
+                    ),
+                    fare=fare,
+                    status=status,
+                    chair=app_get_notification_response_chair,
+                    created_at=timestamp_millis(ride.created_at),
+                    updated_at=timestamp_millis(ride.updated_at),
+                )
+                yield str(data.model_dump_json(exclude_none=True))
+
+        yield next(f())
+
+        while True:
+            # TODO: 同期的に止める方法を考える
+            # if request.is_disconnected():
+            #     break
+            yield next(f())
+            time.sleep(0.1)
+
+    return EventSourceResponse(event_stream(), media_type="text/event-stream")

--- a/webapp/python/pyproject.toml
+++ b/webapp/python/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "pymysql>=1.1.1",
     "python-ulid>=3.0.0",
     "sqlalchemy>=2.0.36",
+    "sse-starlette>=2.1.3",
     "urllib3>=2.2.3",
     "uvicorn-worker>=0.2.0",
 ]

--- a/webapp/python/uv.lock
+++ b/webapp/python/uv.lock
@@ -98,6 +98,7 @@ dependencies = [
     { name = "pymysql" },
     { name = "python-ulid" },
     { name = "sqlalchemy" },
+    { name = "sse-starlette" },
     { name = "urllib3" },
     { name = "uvicorn-worker" },
 ]
@@ -109,6 +110,7 @@ requires-dist = [
     { name = "pymysql", specifier = ">=1.1.1" },
     { name = "python-ulid", specifier = ">=3.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
+    { name = "sse-starlette", specifier = ">=2.1.3" },
     { name = "urllib3", specifier = ">=2.2.3" },
     { name = "uvicorn-worker", specifier = ">=0.2.0" },
 ]
@@ -206,6 +208,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/95/81babb6089938680dfe2cd3f88cd3fd39cccd1543b7cb603b21ad881bff1/SQLAlchemy-2.0.36-cp313-cp313-win32.whl", hash = "sha256:0572f4bd6f94752167adfd7c1bed84f4b240ee6203a95e05d1e208d488d0d436", size = 2060439 },
     { url = "https://files.pythonhosted.org/packages/c1/ce/5f7428df55660d6879d0522adc73a3364970b5ef33ec17fa125c5dbcac1d/SQLAlchemy-2.0.36-cp313-cp313-win_amd64.whl", hash = "sha256:8c78ac40bde930c60e0f78b3cd184c580f89456dd87fc08f9e3ee3ce8765ce88", size = 2084574 },
     { url = "https://files.pythonhosted.org/packages/b8/49/21633706dd6feb14cd3f7935fc00b60870ea057686035e1a99ae6d9d9d53/SQLAlchemy-2.0.36-py3-none-any.whl", hash = "sha256:fddbe92b4760c6f5d48162aef14824add991aeda8ddadb3c31d56eb15ca69f8e", size = 1883787 },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "2.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/fc/56ab9f116b2133521f532fce8d03194cf04dcac25f583cf3d839be4c0496/sse_starlette-2.1.3.tar.gz", hash = "sha256:9cd27eb35319e1414e3d2558ee7414487f9529ce3b3cf9b21434fd110e017169", size = 19678 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/aa/36b271bc4fa1d2796311ee7c7283a3a1c348bad426d37293609ca4300eef/sse_starlette-2.1.3-py3-none-any.whl", hash = "sha256:8ec846438b4665b9e8c560fcdea6bc8081a3abf7942faa95e5a744999d219772", size = 9383 },
 ]
 
 [[package]]


### PR DESCRIPTION
`sse-starlette` を用いて `/api/app/notificaiton` を置き換える例
FastAPI only なら StreamingResponse が使えそうですが、async でない実装があまり落ちてない。
FastAPIが内部で使っている starlette のプラグインで対応しました。

実装した感想としてはSSEのデータ構造がベンチマーカのコードを見ないと、
何を送るのか少し難しかったかなという印象がありました。当日はドキュメントをちゃんと読まないと実装できないかも