### PR TITLE
[DO NOT MERGE] rust: Use SSE for notification endpoints

### DIFF
--- a/webapp/rust/Cargo.lock
+++ b/webapp/rust/Cargo.lock
@@ -620,6 +620,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +650,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1058,6 +1070,7 @@ dependencies = [
  "axum",
  "axum-extra",
  "chrono",
+ "futures-util",
  "hex",
  "listenfd",
  "num-traits",

--- a/webapp/rust/Cargo.toml
+++ b/webapp/rust/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 axum = "0.7"
 axum-extra = { version = "0.9", features = ["cookie"] }
 chrono = "0.4"
+futures-util = "0.3"
 hex = "0.4"
 listenfd = "1"
 num-traits = "0.2"

--- a/webapp/rust/src/main.rs
+++ b/webapp/rust/src/main.rs
@@ -3,7 +3,7 @@ use isuride::{AppState, Error};
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
 
-#[tokio::main]
+#[tokio::main(worker_threads = 24)]
 async fn main() -> anyhow::Result<()> {
     if std::env::var_os("RUST_LOG").is_none() {
         std::env::set_var("RUST_LOG", "info,tower_http=debug,axum::rejection=trace");
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
     let dbname = std::env::var("ISUCON_DB_NAME").unwrap_or_else(|_| "isuride".to_owned());
 
     let pool = sqlx::mysql::MySqlPoolOptions::new()
-        .max_connections(50)
+        .max_connections(100)
         .connect_with(
             sqlx::mysql::MySqlConnectOptions::default()
                 .host(&host)


### PR DESCRIPTION
Rust で SSE を実装する例です。Axum の sse モジュールを使って実装しています。
https://docs.rs/axum/0.7.9/axum/response/sse/index.html

portal-stg で何度かベンチマークを動かしてみましたが `level=ERROR msg=クリティカルエラーが発生しました error="ライドが長時間マッチングされませんでした (CODE=31)"` でまぁまぁの確率で失敗していて、Tokio の worker_threads の数を増やしたりしてみましたが現状そこまで安定してません。ただ、フレームワーク上の問題ではないと思うので SSE 実装ができないわけではないはず……