### PR TITLE
クリティカルでないエラーを`contestantLogger.Warn`で出力する

### DIFF
--- a/bench/benchmarker/world/world.go
+++ b/bench/benchmarker/world/world.go
@@ -467,7 +467,7 @@ func (w *World) handleTickError(err error) {
 		_ = w.ErrorCounter.Add(err)
 		w.criticalErrorCh <- err
 	} else {
-		w.contestantLogger.Error(err.Error())
+		w.contestantLogger.Warn(err.Error())
 		if err2 := w.ErrorCounter.Add(err); err2 != nil {
 			w.criticalErrorCh <- err2
 		}


### PR DESCRIPTION
closes #695 