### PR TITLE
(Ruby)🐛 fix empty

### DIFF
--- a/webapp/ruby/lib/isuride/app_handler.rb
+++ b/webapp/ruby/lib/isuride/app_handler.rb
@@ -62,7 +62,7 @@ module Isuride
         tx.xquery('INSERT INTO coupons (user_id, code, discount) VALUES (?, ?, ?)', user_id, 'CP_NEW2024', 3000)
 
 	# 招待コードを使った登録
-        unless req.invitation_code.nil?
+        unless req.invitation_code.nil? || req.invitation_code.empty?
           # 招待する側の招待数をチェック
           coupons = tx.xquery('SELECT * FROM coupons WHERE code = ? FOR UPDATE', "INV_#{req.invitation_code}").to_a
           if coupons.size >= 3


### PR DESCRIPTION
トークンが空の時に

> ユーザーの登録に失敗しました。接続に問題があるか、ユーザー名が登録済みの可能性があります。

というエラーが出てフロントエンドが進めなくなっていたため修正