### PR TITLE
fix(node): 常にconnection.rollbackを呼び出す

### DIFF
--- a/webapp/nodejs/src/main.ts
+++ b/webapp/nodejs/src/main.ts
@@ -49,8 +49,12 @@ app.use(
   createMiddleware<Environment>(async (ctx, next) => {
     const connection = await pool.getConnection();
     ctx.set("dbConn", connection);
-    await next();
-    pool.releaseConnection(connection);
+    try {
+      await next();
+    } finally {
+      await connection.rollback();
+      pool.releaseConnection(connection);
+    }
   }),
 );
 


### PR DESCRIPTION
https://github.com/isucon/isucon14/blob/0d7cec22dc4a7a412005ca45da1764b5c0e77d76/webapp/nodejs/src/app_handlers.ts#L463
などでearly returnした際に`ctx.var.dbConn`に対して明示的な`commit`や`rollback`が呼ばれないため、次にそのコネクションが使いまわされる際にimplicit commitが発生して、意図しない変更がcommitされることがありました
https://dev.classmethod.jp/articles/nodejs-mysql-implicit-commit/
それが https://github.com/isucon/isucon14/actions/runs/12212467610/job/34070952759#step:12:18 のCIのエラーにつながったと考えています

このPRでは`await connection.rollback();`を呼び出すことでimplicit commitが発生することを防ぐようにしました
`try-finally`はそんなに重要ではないですが、try-catch外でエラーが起きてimplicit commitが起こることも防ぐようにしておきました
